### PR TITLE
add-ping-endpoint-and-fix-agent-instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ For any requested change, follow this sequence:
 Do not skip validation.
 Do not bypass PR review.
 Do not mix unrelated cleanup into the same change.
+Before proposing exact code changes, inspect the target files that will be modified
 
 ---
 
@@ -190,6 +191,11 @@ Preferred rules:
 - match the style of existing tests
 - add or update tests for new behavior
 - do not remove tests unless explicitly requested and justified
+- always inspect existing tests and follow the same patterns (e.g. how TestClient is created)
+- do not introduce new pytest fixtures (e.g. `client`) unless they already exist in the codebase
+- prefer copying an existing test pattern over inventing a new one
+- when giving exact test code, first inspect the existing test file and match its pattern
+- if the existing test file was not inspected, do not assume fixtures or local test helpers; state the assumption explicitly
 
 At minimum:
 - new endpoint → add endpoint tests
@@ -202,6 +208,8 @@ If tests cannot be run:
 - say so explicitly
 - explain why
 - do not pretend validation happened
+
+
 
 ---
 

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter
+from datetime import datetime, UTC
 
 router = APIRouter()
 
@@ -6,3 +7,11 @@ router = APIRouter()
 @router.get("/health")
 async def health():
     return {"status": "ok"}
+
+
+@router.get("/ping")
+async def ping():
+    return {
+        "status": "ok",
+        "timestamp": datetime.now(UTC).isoformat(),
+    }

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -27,12 +27,29 @@ def test_get_tags_includes_fish():
     response = client.get("/tags")
     assert "fish" in response.json()
 
-# ── Recipes (healthcheck) ─────────────────────────────────────────────────
+# ── health ─────────────────────────────────────────────────
 def test_health_returns_200():
     response = client.get("/health")
 
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+# ── ping ────────────────────────────────────────────────
+
+def test_ping_returns_200(client):
+    response = client.get("/ping")
+    assert response.status_code == 200
+
+
+def test_ping_returns_status_ok_and_timestamp(client):
+    response = client.get("/ping")
+    data = response.json()
+
+    assert data["status"] == "ok"
+    assert "timestamp" in data
+
+    from datetime import datetime
+    datetime.fromisoformat(data["timestamp"].replace("Z", "+00:00"))
 
 
 # ── Recipes (GET) ─────────────────────────────────────────────────
@@ -233,3 +250,5 @@ def test_delete_nonexistent_recipe_returns_404():
 
         assert response.status_code == 404
         assert response.json()["detail"] == "Recipe not found"
+
+


### PR DESCRIPTION
Added /ping endpoint as a test, to check if a new chat in chatgpt, providing the agent.md and agent-playbook.md, plus a prompt like the following, provided the correct results. 
CONCLUSSION: almost good, although messed up some tests. Will do again in a next version exact same experiment but with modifications to the agent.md and agent-playbook.md

PROMPT:

Follow AGENTS.md and agent-playbook.md strictly.

Task:
Add a /ping endpoint returning current timestamp.

Requirements:
- Give exact files to modify
- Give exact code to paste
- Specify where to paste it
- Add tests
- Keep changes minimal
- Do not overengineer