### PR TITLE
Add /version endpoint with tests

### DIFF
--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -15,3 +15,10 @@ def ping():
         "status": "ok",
         "timestamp": datetime.now(UTC).isoformat(),
     }
+
+@router.get("/version")
+def version():
+    return {
+        "version": "0.1",
+        "timestamp": datetime.now(UTC).isoformat(),
+    }

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -52,6 +52,25 @@ def test_ping_returns_status_ok_and_timestamp():
     datetime.fromisoformat(data["timestamp"].replace("Z", "+00:00"))
 
 
+
+# ── version ────────────────────────────────────────────────
+
+def test_version_returns_200():
+    response = client.get("/version")
+    assert response.status_code == 200
+
+
+def test_version_returns_expected_payload():
+    response = client.get("/version")
+    data = response.json()
+
+    assert data["version"] == "0.1"
+    assert "timestamp" in data
+
+    from datetime import datetime
+    datetime.fromisoformat(data["timestamp"].replace("Z", "+00:00"))
+
+
 # ── Recipes (GET) ─────────────────────────────────────────────────
 
 def test_get_recipes_returns_200():


### PR DESCRIPTION
### Motivation
- Provide a minimal `/version` endpoint that returns the app version and a current UTC ISO 8601 timestamp for simple health/version checks while keeping changes small and colocated with existing health endpoints.

### Description
- Added `GET /version` in `backend/app/routers/health.py` which returns `{"version": "0.1", "timestamp": "<UTC iso>"}`, and added two tests to `backend/test_main.py` that assert HTTP 200, the `version` value, and a parseable ISO timestamp.

### Testing
- Ran `cd backend && pytest test_main.py` and the backend test suite passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd04be4620832aaf458f33345c912f)