### PR TITLE
Add X-Service-Name header to /health response

### DIFF
--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -1,11 +1,12 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Response
 from datetime import datetime, UTC
 
 router = APIRouter()
 
 
 @router.get("/health")
-async def health():
+async def health(response: Response):
+    response.headers["X-Service-Name"] = "meal-planner"
     return {"status": "ok"}
 
 

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -34,6 +34,12 @@ def test_health_returns_200():
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
 
+
+def test_health_includes_service_name_header():
+    response = client.get("/health")
+
+    assert response.headers["X-Service-Name"] == "meal-planner"
+
 # ── ping ────────────────────────────────────────────────
 
 def test_ping_returns_200():


### PR DESCRIPTION
### Motivation
- Expose a simple service identifier header `X-Service-Name: meal-planner` on the existing `/health` endpoint so clients can recognize the service without changing the JSON body.

### Description
- Import `Response` and set `response.headers["X-Service-Name"] = "meal-planner"` in `backend/app/routers/health.py`, and add `test_health_includes_service_name_header` to `backend/test_main.py`; files changed: `backend/app/routers/health.py`, `backend/test_main.py`.

### Testing
- Ran `pytest backend/test_main.py` and all tests passed (`18 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd0bccbf48832a956a57d661800d8d)