### PR TITLE
Add message field to /ping response

### DIFF
--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -15,6 +15,7 @@ def ping():
     return {
         "status": "ok",
         "timestamp": datetime.now(UTC).isoformat(),
+        "message": "pong",
     }
 
 @router.get("/version")

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -47,11 +47,12 @@ def test_ping_returns_200():
     assert response.status_code == 200
 
 
-def test_ping_returns_status_ok_and_timestamp():
+def test_ping_returns_status_ok_timestamp_and_message():
     response = client.get("/ping")
     data = response.json()
 
     assert data["status"] == "ok"
+    assert data["message"] == "pong"
     assert "timestamp" in data
 
     from datetime import datetime


### PR DESCRIPTION
### Motivation
- Extend the existing `/ping` response with a simple `message` field set to `"pong"` while preserving the current `status` and UTC `timestamp` behavior and keeping the change minimal and backward-compatible.

### Description
- Added the `"message": "pong"` field to the `/ping` response in `backend/app/routers/health.py` and updated the ping test in `backend/test_main.py` to assert the new field without changing the timestamp validation.

### Testing
- Ran the test suite with `cd backend && pytest test_main.py` and all tests passed (`18 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd127dda6c832aa65ce36c3d99311e)