### PR TITLE
Remove unused pygame from backend requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,7 +15,6 @@ pandas==2.2.3
 pluggy==1.6.0
 pydantic==2.12.5
 pydantic_core==2.41.5
-pygame==2.6.1
 Pygments==2.19.2
 pyperclip==1.9.0
 pytest==9.0.2


### PR DESCRIPTION
### Motivation
- Remove an unnecessary SDL-dependent package that was blocking Render deployments by ensuring backend requirements only include packages the backend actually uses.

### Description
- Deleted `pygame==2.6.1` from `backend/requirements.txt` and kept the change scoped to that file only, with no code changes to backend modules.

### Testing
- Verified no backend imports with `rg -n "pygame" backend` and ran `cd backend && pytest test_main.py`, which executed 18 tests and all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c402a8f1f4832ab85b36a98727afc6)