### PR TITLE
Add status field to /version response

### DIFF
--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -21,6 +21,7 @@ def ping():
 @router.get("/version")
 def version():
     return {
+        "status": "ok",
         "version": "0.1",
         "timestamp": datetime.now(UTC).isoformat(),
     }

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -71,6 +71,7 @@ def test_version_returns_expected_payload():
     response = client.get("/version")
     data = response.json()
 
+    assert data["status"] == "ok"
     assert data["version"] == "0.1"
     assert "timestamp" in data
 


### PR DESCRIPTION
### Motivation
- Make the `/version` response consistent with other health endpoints by including a `status: "ok"` field.

### Description
- Added `"status": "ok"` to the `/version` endpoint response in `backend/app/routers/health.py` and updated the corresponding assertion in `backend/test_main.py` to validate the new field.

### Testing
- Ran the backend test suite with `cd backend && pytest test_main.py` and all tests passed (`19 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4fdae798c832a8c83dd5aad7afe26)