### PR TITLE
DRAFT: Simplify recipe list UI with expandable details

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,8 +22,12 @@
     #loading { margin-top: 20px; color: #666; }
 
     /* Recipe list */
-    .recipe-card { border: 1px solid #ddd; border-radius: 6px; padding: 14px 16px; margin-bottom: 12px; }
-    .recipe-card-header { display: flex; justify-content: space-between; align-items: flex-start; }
+    .recipe-card { border: 1px solid #ddd; border-radius: 6px; margin-bottom: 10px; overflow: hidden; }
+    .recipe-name-btn { width: 100%; text-align: left; background: #fff; border: none; padding: 12px 14px; margin: 0; font-size: 15px; font-weight: bold; cursor: pointer; }
+    .recipe-name-btn:hover { background: #fafafa; }
+    .recipe-details { padding: 0 14px 14px 14px; border-top: 1px solid #eee; }
+    .recipe-details.hidden { display: none; }
+    .recipe-card-header { display: flex; justify-content: space-between; align-items: flex-start; margin-top: 10px; }
     .recipe-actions { display: flex; gap: 8px; }
     .recipe-card h3 { margin: 0 0 6px 0; font-size: 16px; }
     .recipe-meta { font-size: 13px; color: #666; margin-bottom: 8px; }
@@ -190,6 +194,7 @@
       try {
         const res = await fetch(apiUrl('/recipes'));
         const recipes = await res.json();
+        recipes.sort((a, b) => a.name.localeCompare(b.name));
 
         loadingEl.style.display = 'none';
 
@@ -206,7 +211,9 @@
             .join('');
 
           return `
-            <div class="recipe-card">
+            <div class="recipe-card" data-recipe-id="${r.id}">
+              <button class="recipe-name-btn" onclick="toggleRecipeDetails(${r.id})">${r.name}</button>
+              <div class="recipe-details hidden" id="recipe-details-${r.id}">
               <div class="recipe-card-header">
                 <h3>${r.name}</h3>
                 <div class="recipe-actions">
@@ -216,6 +223,7 @@
               </div>
               <div class="recipe-meta">${prep} &nbsp;|&nbsp; ${tags || 'sin etiquetas'}</div>
               ${ingredients ? `<ul class="ingredient-list">${ingredients}</ul>` : ''}
+              </div>
             </div>`;
         }).join('');
 
@@ -223,6 +231,15 @@
         loadingEl.style.display = 'none';
         container.innerHTML = `<p style="color:red">No se pudieron cargar las recetas: ${err.message}</p>`;
       }
+    }
+
+    function toggleRecipeDetails(id) {
+      const detailEls = document.querySelectorAll('.recipe-details');
+      const selected = document.getElementById(`recipe-details-${id}`);
+      const shouldOpen = selected.classList.contains('hidden');
+
+      detailEls.forEach(el => el.classList.add('hidden'));
+      if (shouldOpen) selected.classList.remove('hidden');
     }
 
     // ── Show/hide form ────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Reduce visual clutter in the Recipes tab by showing recipe names first and hiding details until requested to improve browsing (issue #36).
- Ensure a predictable alphabetical presentation on the client-side so recipes render A→Z regardless of backend ordering.

### Description
- Modified `frontend/index.html` to present recipes as a name-first list with an inline expandable details panel and updated styles (`.recipe-name-btn`, `.recipe-details`, and adjusted `.recipe-card`).
- Added client-side alphabetical sorting using `localeCompare` and a `toggleRecipeDetails` function to open one recipe's details at a time.
- Kept existing edit/delete controls and backend interactions unchanged so behavior and endpoints are preserved.

### Testing
- Ran backend tests with `cd backend && pytest test_main.py` which passed (`19 passed`).
- No automated frontend tests were added because the change is a UI-only enhancement and existing test suite covers backend behavior only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c963841234832a9eef1d8b5c681a00)