### PR TITLE
[DRAFT] Add single-day meal replacement support to weekly plan

### DIFF
--- a/backend/app/routers/meal_plan.py
+++ b/backend/app/routers/meal_plan.py
@@ -1,9 +1,30 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
 
-from app.services.meal_plan_service import generate_plan_service
+from app.services.meal_plan_service import generate_plan_service, generate_day_replacement_service
 
 router = APIRouter()
+
+
+class DayReplacementRequest(BaseModel):
+    day: str
+    current_recipe: str
+    used_recipes: list[str] = Field(default_factory=list)
+
 
 @router.post("/generate-plan")
 async def generate_plan():
     return await generate_plan_service()
+
+
+@router.post("/generate-day-replacement")
+async def generate_day_replacement(payload: DayReplacementRequest):
+    replacement = await generate_day_replacement_service(
+        current_recipe=payload.current_recipe,
+        used_recipes=payload.used_recipes,
+    )
+
+    if not replacement:
+        raise HTTPException(status_code=400, detail="No replacement recipe available")
+
+    return {"day": payload.day, "recipe": replacement}

--- a/backend/app/services/meal_plan_service.py
+++ b/backend/app/services/meal_plan_service.py
@@ -1,3 +1,5 @@
+import random
+
 import httpx
 
 from app.config import SUPABASE_URL, SUPABASE_HEADERS, ANTHROPIC_API_KEY
@@ -55,3 +57,28 @@ Respond with exactly this JSON format:
 
     data = claude_response.json()
     return data["content"][0]["text"]
+
+
+async def generate_day_replacement_service(current_recipe: str, used_recipes: list[str]):
+    async with httpx.AsyncClient() as client:
+        recipes_response = await client.get(
+            f"{SUPABASE_URL}/rest/v1/recipes?select=name",
+            headers=SUPABASE_HEADERS,
+        )
+
+    recipes = recipes_response.json()
+    all_recipe_names = [recipe["name"] for recipe in recipes]
+
+    preferred_candidates = [
+        name for name in all_recipe_names
+        if name != current_recipe and name not in used_recipes
+    ]
+
+    if preferred_candidates:
+        return random.choice(preferred_candidates)
+
+    fallback_candidates = [name for name in all_recipe_names if name != current_recipe]
+    if fallback_candidates:
+        return random.choice(fallback_candidates)
+
+    return None

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -249,6 +249,59 @@ def test_generate_plan_contains_all_four_days():
         for day in ["monday", "tuesday", "wednesday", "thursday"]:
             assert day in plan, f"Missing day: {day}"
 
+
+def test_generate_day_replacement_returns_200_and_recipe():
+    mock_recipes = [
+        {"name": "Grilled Salmon"},
+        {"name": "Chicken pasta"},
+        {"name": "Beef stew"},
+    ]
+
+    with patch("app.services.meal_plan_service.httpx.AsyncClient") as mock_client, \
+         patch("app.services.meal_plan_service.random.choice", return_value="Beef stew"):
+        mock_recipes_res = MagicMock()
+        mock_recipes_res.json.return_value = mock_recipes
+
+        mock_get = AsyncMock(return_value=mock_recipes_res)
+        mock_client.return_value.__aenter__.return_value.get = mock_get
+
+        response = client.post(
+            "/generate-day-replacement",
+            json={
+                "day": "monday",
+                "current_recipe": "Chicken pasta",
+                "used_recipes": ["Grilled Salmon"],
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"day": "monday", "recipe": "Beef stew"}
+
+
+def test_generate_day_replacement_returns_400_when_no_candidate():
+    mock_recipes = [
+        {"name": "Chicken pasta"},
+    ]
+
+    with patch("app.services.meal_plan_service.httpx.AsyncClient") as mock_client:
+        mock_recipes_res = MagicMock()
+        mock_recipes_res.json.return_value = mock_recipes
+
+        mock_get = AsyncMock(return_value=mock_recipes_res)
+        mock_client.return_value.__aenter__.return_value.get = mock_get
+
+        response = client.post(
+            "/generate-day-replacement",
+            json={
+                "day": "wednesday",
+                "current_recipe": "Chicken pasta",
+                "used_recipes": [],
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "No replacement recipe available"
+
 # ── Recipes (DELETE) ────────────────────────────────────────────────
 
 def test_delete_recipe_returns_success():

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,6 +18,12 @@
     /* Meal plan */
     button { padding: 10px 20px; font-size: 15px; cursor: pointer; margin-top: 10px; }
     .day { padding: 10px; margin: 5px 0; background: #f5f5f5; border-radius: 4px; }
+    .day-header { display: flex; justify-content: space-between; align-items: center; gap: 10px; }
+    .day-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+    .day-action-btn { margin-top: 0; padding: 6px 12px; font-size: 13px; }
+    .day-manual-row { display: none; margin-top: 8px; gap: 8px; align-items: center; flex-wrap: wrap; }
+    .day-manual-row.visible { display: flex; }
+    .day-manual-row select { min-width: 220px; padding: 6px; }
     #error { color: red; margin-top: 20px; }
     #loading { margin-top: 20px; color: #666; }
 
@@ -134,6 +140,8 @@
 
     let currentEditId = null; // null = adding, number = editing
     let currentTagOptions = [];
+    let currentPlan = null;
+    let plannerRecipes = [];
 
     const BACKEND_CONFIG = {
       local: 'http://127.0.0.1:8000',
@@ -171,24 +179,119 @@
       try {
         const response = await fetch(apiUrl('/generate-plan'), { method: 'POST' });
         const result = await response.json();
-        const plan = JSON.parse(result);
-        const days = ['monday', 'tuesday', 'wednesday', 'thursday'];
-        const dayLabels = {
-          monday: 'Lunes',
-          tuesday: 'Martes',
-          wednesday: 'Miércoles',
-          thursday: 'Jueves'
-        };
-
-        planDiv.innerHTML = '<h2>Plan de esta semana:</h2>' +
-          days.map(day =>
-            `<div class="day"><strong>${dayLabels[day]}:</strong> ${plan[day]}</div>`
-          ).join('');
+        currentPlan = JSON.parse(result);
+        plannerRecipes = await fetchPlannerRecipes();
+        renderMealPlan();
       } catch (err) {
         error.textContent = 'Algo salió mal: ' + err.message;
       } finally {
         loading.style.display = 'none';
       }
+    }
+
+    const PLAN_DAYS = ['monday', 'tuesday', 'wednesday', 'thursday'];
+    const DAY_LABELS = {
+      monday: 'Lunes',
+      tuesday: 'Martes',
+      wednesday: 'Miércoles',
+      thursday: 'Jueves'
+    };
+
+    async function fetchPlannerRecipes() {
+      const response = await fetch(apiUrl('/recipes'));
+      const recipes = await response.json();
+      return recipes.map(r => r.name).sort((a, b) => a.localeCompare(b));
+    }
+
+    function renderMealPlan() {
+      const planDiv = document.getElementById('meal-plan');
+      if (!currentPlan) return;
+
+      planDiv.innerHTML = '<h2>Plan de esta semana:</h2>' +
+        PLAN_DAYS.map(day => `
+          <div class="day">
+            <div class="day-header">
+              <div>
+                <strong>${DAY_LABELS[day]}:</strong>
+                <span id="meal-name-${day}">${escapeHtml(currentPlan[day] || '')}</span>
+              </div>
+              <div class="day-actions">
+                <button class="day-action-btn" onclick="toggleManualChange('${day}')">Cambiar</button>
+                <button class="day-action-btn" onclick="regenerateDay('${day}')">Regenerar</button>
+              </div>
+            </div>
+            <div class="day-manual-row" id="manual-row-${day}">
+              <select id="manual-select-${day}">
+                ${buildRecipeOptions(currentPlan[day])}
+              </select>
+              <button class="day-action-btn" onclick="applyManualChange('${day}')">Guardar</button>
+            </div>
+          </div>
+        `).join('');
+    }
+
+    function buildRecipeOptions(selectedRecipe) {
+      return plannerRecipes
+        .map(name => {
+          const selected = name === selectedRecipe ? 'selected' : '';
+          return `<option value="${escapeHtml(name)}" ${selected}>${escapeHtml(name)}</option>`;
+        })
+        .join('');
+    }
+
+    function toggleManualChange(day) {
+      const row = document.getElementById(`manual-row-${day}`);
+      const select = document.getElementById(`manual-select-${day}`);
+      select.innerHTML = buildRecipeOptions(currentPlan[day]);
+      row.classList.toggle('visible');
+    }
+
+    function applyManualChange(day) {
+      const select = document.getElementById(`manual-select-${day}`);
+      const selectedRecipe = select.value;
+      if (!selectedRecipe) return;
+
+      currentPlan[day] = selectedRecipe;
+      updateDayInUi(day);
+      document.getElementById(`manual-row-${day}`).classList.remove('visible');
+    }
+
+    async function regenerateDay(day) {
+      const error = document.getElementById('error');
+      error.textContent = '';
+
+      try {
+        const usedRecipes = PLAN_DAYS
+          .filter(d => d !== day)
+          .map(d => currentPlan[d])
+          .filter(Boolean);
+
+        const response = await fetch(apiUrl('/generate-day-replacement'), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            day,
+            current_recipe: currentPlan[day],
+            used_recipes: usedRecipes
+          })
+        });
+
+        if (!response.ok) throw new Error('No se pudo regenerar la comida');
+
+        const data = await response.json();
+        currentPlan[day] = data.recipe;
+        updateDayInUi(day);
+      } catch (err) {
+        error.textContent = 'No se pudo regenerar el día: ' + err.message;
+      }
+    }
+
+    function updateDayInUi(day) {
+      const mealName = document.getElementById(`meal-name-${day}`);
+      if (mealName) mealName.textContent = currentPlan[day] || '';
+
+      const select = document.getElementById(`manual-select-${day}`);
+      if (select) select.innerHTML = buildRecipeOptions(currentPlan[day]);
     }
 
     // ── Recipe list ───────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Provide the ability to replace or regenerate a single day's dinner in a generated weekly plan without regenerating the whole week, addressing issue #41.
- Prefer minimal, incremental changes that keep business logic in services and UI changes localized to the planner view.

### Description
- Added a new backend endpoint `POST /generate-day-replacement` with a `DayReplacementRequest` Pydantic model to validate `day`, `current_recipe`, and `used_recipes` inputs and return `400` when no replacement is available.
- Implemented `generate_day_replacement_service` in `backend/app/services/meal_plan_service.py` which fetches recipe names, prefers candidates that are different from the current recipe and not already used in the week, falls back to any recipe different from the current one, and returns `None` when no candidate exists.
- Updated frontend (`frontend/index.html`) to render per-day controls after generating the weekly plan, adding `Cambiar` (manual selector) and `Regenerar` (backend call) actions and updating only the affected day in UI state; manual replacements are handled client-side using the recipes list.
- Added two backend tests in `backend/test_main.py` covering successful replacement and the no-candidate (400) case.

### Testing
- Ran `cd backend && pytest test_main.py` and all tests passed (`23 passed`).
- New tests `test_generate_day_replacement_returns_200_and_recipe` and `test_generate_day_replacement_returns_400_when_no_candidate` were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cad961622c832a9c7bcbf677154b8b)