### PR TITLE
Use same-origin backend URL in frontend to fix regenerate-day 404

### DIFF
--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -26,6 +26,11 @@ def test_frontend_includes_add_tag_button():
     assert response.status_code == 200
     assert "Añadir etiqueta" in response.text
 
+def test_frontend_uses_same_origin_backend_url_for_production():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "window.location.origin" in response.text
+
 
 # ── Tags ──────────────────────────────────────────────────────────
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -143,14 +143,9 @@
     let currentPlan = null;
     let plannerRecipes = [];
 
-    const BACKEND_CONFIG = {
-      local: 'http://127.0.0.1:8000',
-      production: 'https://meal-planner-igpk.onrender.com'
-    };
-
     const BACKEND_BASE_URL = ['localhost', '127.0.0.1'].includes(window.location.hostname)
-      ? BACKEND_CONFIG.local
-      : BACKEND_CONFIG.production;
+      ? 'http://127.0.0.1:8000'
+      : window.location.origin;
 
     function apiUrl(path) {
       return `${BACKEND_BASE_URL}${path}`;


### PR DESCRIPTION
### Motivation
- The regenerate-day flow could target a hardcoded production host, which can be stale and cause 404s when the frontend is deployed to a different origin. 
- The smallest safe fix is to make production requests use the current page origin while preserving the local development behavior. 

### Description
- Update `frontend/index.html` to remove the hardcoded `BACKEND_CONFIG` and set `BACKEND_BASE_URL` to `http://127.0.0.1:8000` for local hosts or `window.location.origin` for non-local environments. 
- This keeps API calls on the same origin in production and avoids routing regenerate requests to an outdated backend. 
- Add a regression test in `backend/test_main.py` that asserts the served frontend contains `window.location.origin` in its API URL configuration. 

### Testing
- Ran the backend test suite with `cd backend && pytest test_main.py`. 
- All tests passed: `24 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cadd8d6534832a8a78027b56f103fe)