### PR TITLE
Draft: Populate legacy `week_start` when saving meal plans

### DIFF
--- a/backend/app/services/meal_plan_service.py
+++ b/backend/app/services/meal_plan_service.py
@@ -133,6 +133,7 @@ async def generate_and_save_meal_plan_for_date_service(target_date: date | None 
 
     payload = {
         "week_start_date": week_start_date.isoformat(),
+        "week_start": week_start_date.isoformat(),
         "monday": generated_plan.get("monday"),
         "tuesday": generated_plan.get("tuesday"),
         "wednesday": generated_plan.get("wednesday"),

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -473,8 +473,9 @@ def test_generate_meal_plan_creates_plan_for_week():
 
     with patch("app.services.meal_plan_service.WEEK_START_DAY", "sunday"), \
         patch("app.services.meal_plan_service.generate_plan_service", AsyncMock(return_value=generated_plan)), \
-         patch("app.services.meal_plan_service.httpx.AsyncClient") as mock_client:
+        patch("app.services.meal_plan_service.httpx.AsyncClient") as mock_client:
         mock_response = MagicMock()
+        mock_response.status_code = 200
         mock_response.raise_for_status = MagicMock()
         mock_response.json.return_value = saved_plan
         mock_post = AsyncMock(return_value=mock_response)
@@ -484,9 +485,11 @@ def test_generate_meal_plan_creates_plan_for_week():
 
         assert response.status_code == 200
         assert response.json()["week_start_date"] == "2026-03-29"
-        mock_response.raise_for_status.assert_called_once()
         post_headers = mock_post.await_args.kwargs["headers"]
+        post_payload = mock_post.await_args.kwargs["json"]
         assert post_headers["Prefer"] == "return=representation,resolution=merge-duplicates"
+        assert post_payload["week_start_date"] == "2026-03-29"
+        assert post_payload["week_start"] == "2026-03-29"
 
 
 def test_generate_meal_plan_overwrites_existing_week_plan():
@@ -509,6 +512,7 @@ def test_generate_meal_plan_overwrites_existing_week_plan():
         patch("app.services.meal_plan_service.generate_plan_service", AsyncMock(return_value=first_generated_plan)), \
          patch("app.services.meal_plan_service.httpx.AsyncClient") as mock_client:
         mock_response = MagicMock()
+        mock_response.status_code = 200
         mock_response.raise_for_status = MagicMock()
         mock_response.json.return_value = overwritten_plan
         mock_post = AsyncMock(return_value=mock_response)
@@ -534,6 +538,7 @@ def test_generate_meal_plan_returns_payload_when_supabase_response_is_empty():
          patch("app.services.meal_plan_service.generate_plan_service", AsyncMock(return_value=generated_plan)), \
          patch("app.services.meal_plan_service.httpx.AsyncClient") as mock_client:
         mock_response = MagicMock()
+        mock_response.status_code = 200
         mock_response.raise_for_status = MagicMock()
         mock_response.json.return_value = []
         mock_client.return_value.__aenter__.return_value.post = AsyncMock(return_value=mock_response)


### PR DESCRIPTION
### Motivation
- Supabase schema includes a legacy `week_start` column that must be populated for compatibility with existing constraints, while `week_start_date` remains the canonical field.
- Ensure the app continues to save weekly meal plans without requiring immediate schema migration on the database side.

### Description
- Add `week_start` (ISO date string) to the Supabase save payload alongside `week_start_date` in `generate_and_save_meal_plan_for_date_service` in `backend/app/services/meal_plan_service.py`.
- Update tests in `backend/test_main.py` to assert the outgoing POST payload contains both `week_start_date` and `week_start` and to set explicit mocked `status_code = 200` on Supabase POST mocks.
- Keep the change minimal and focused on payload compatibility without altering canonical conflict key `on_conflict=week_start_date`.
- Modified test assertions to inspect the mocked POST call headers and JSON payload rather than relying on `raise_for_status` being called in the mocked response.

### Testing
- Ran backend tests with `cd backend && pytest test_main.py` and all tests passed: `35 passed`.
- Earlier test iterations uncovered and fixed mock behavior (added `status_code` on mocked responses and adjusted indentation/assertions) before reaching green tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc36c05924832ab43923408a706545)